### PR TITLE
Fix makefile dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /echidnafs/echfs-utils
 /kernel/**/*.o
 /libc/*.o
+/libc/libc
 /misc/*.o
 /shell/*.o
 /misc/life
@@ -17,3 +18,4 @@
 /kernel/blobs/*.bin
 /kernel/echidna.bin
 /coreinutils/build/
+/coreinutils/coreinutils

--- a/README
+++ b/README
@@ -48,7 +48,7 @@ To remove build files and sources that aren't needed anymore.
 Now that every requirement is satisfied, let's build the kernel, the shell,
 and create the image:
 
-    make distro
+    make echidna.img
 
 If make didn't error, congratulations, you managed to build echidnaOS.
 There should be a bootable "echidna.img" image in the project's root now.

--- a/coreinutils/makefile
+++ b/coreinutils/makefile
@@ -1,3 +1,4 @@
+export PATH := ../tools/bin:$(PATH)
 CC = cc
 C_FILES = $(shell find ./src/ -type f -name '*.c')
 

--- a/coreinutils/makefile
+++ b/coreinutils/makefile
@@ -1,72 +1,50 @@
 export PATH := ../tools/bin:$(PATH)
 CC = cc
-C_FILES = $(shell find ./src/ -type f -name '*.c')
+BINARY_NAMES = yes hello true cp rm mv echo false [ cat touch printf
+BINARY_PATHS = $(addprefix build/,$(BINARY_NAMES))
 
 notarget:
 	$(error No target specified)
 
-yes: ./src/yes.c
-	$(CC) ./src/yes.c -o yes
-	mv yes ./build/yes
+build/yes: ./src/yes.c
+	$(CC) ./src/yes.c -o build/yes
 
-hello: ./src/hello.c
-	$(CC) ./src/hello.c -o hello
-	mv hello ./build/hello
+build/hello: ./src/hello.c
+	$(CC) ./src/hello.c -o build/hello
 
-true: ./src/true.c
-	$(CC) ./src/true.c -o true
-	mv true ./build/true
+build/true: ./src/true.c
+	$(CC) ./src/true.c -o build/true
 
-cp: ./src/cp.c
-	$(CC) ./src/cp.c ./src/_copy.c -o cp
-	mv cp ./build/cp
+build/cp: ./src/cp.c
+	$(CC) ./src/cp.c ./src/_copy.c -o build/cp
 
-rm: ./src/rm.c
-	$(CC) ./src/rm.c -o rm
-	mv rm ./build/rm
+build/rm: ./src/rm.c
+	$(CC) ./src/rm.c -o build/rm
 
-mv: ./src/mv.c
-	$(CC) ./src/mv.c ./src/_copy.c -o mv
-	mv mv ./build/mv
+build/mv: ./src/mv.c
+	$(CC) ./src/mv.c ./src/_copy.c -o build/mv
 
-echo: ./src/echo.c
-	$(CC) ./src/echo.c -o echo
-	mv echo ./build/echo
+build/echo: ./src/echo.c
+	$(CC) ./src/echo.c -o build/echo
 
-false: ./src/false.c
-	$(CC) ./src/false.c -o false
-	mv false ./build/false
+build/false: ./src/false.c
+	$(CC) ./src/false.c -o build/false
 
-test: ./src/test.c
-	$(CC) ./src/test.c -o [
-	mv [ ./build/[
+build/[: ./src/test.c
+	$(CC) ./src/test.c -o build/[
 
-cat: ./src/cat.c
-	$(CC) ./src/cat.c -o cat
-	mv cat ./build/cat
+build/cat: ./src/cat.c
+	$(CC) ./src/cat.c -o build/cat
 
-touch: ./src/touch.c
-	$(CC) ./src/touch.c -o touch
-	mv touch ./build/touch
+build/touch: ./src/touch.c
+	$(CC) ./src/touch.c -o build/touch
 
-printf: ./src/printf.c
-	$(CC) ./src/printf.c -o printf
-	mv printf ./build/printf
+build/printf: ./src/printf.c
+	$(CC) ./src/printf.c -o build/printf
 
-all: $(C_FILES)
-	mkdir build 2> /dev/null || true
-	make yes
-	make hello
-	make true
-	make cp
-	make rm
-	make mv
-	make echo
-	make false
-#	make test
-	make cat
-	make touch
-	make printf
+all: $(BINARY_PATHS)
+	mkdir -p build
+	touch coreinutils
 
 clean:
 	rm -rf build

--- a/kernel/makefile
+++ b/kernel/makefile
@@ -1,3 +1,4 @@
+export PATH := ../tools/bin:$(PATH)
 CC = kcc
 PREFIX = 
 

--- a/kernel/makefile
+++ b/kernel/makefile
@@ -2,10 +2,10 @@ export PATH := ../tools/bin:$(PATH)
 CC = kcc
 PREFIX = 
 
-C_FILES = ./init.c $(shell find ./src/ -type f -name '*.c')
-H_FILES = $(shell find ./ -type f -name '*.h')
-ASM_FILES = $(shell find ./asm/ -type f -name '*.asm')
-REAL_FILES = $(shell find ./blobs/ -type f -name '*.real')
+C_FILES = init.c $(shell find src -type f -name '*.c')
+H_FILES = $(shell find . -type f -name '*.h')
+ASM_FILES = $(shell find asm -type f -name '*.asm')
+REAL_FILES = $(shell find blobs -type f -name '*.real')
 OBJ = $(C_FILES:.c=.o) $(ASM_FILES:.asm=.o)
 BINS = $(REAL_FILES:.real=.bin)
 

--- a/libc/makefile
+++ b/libc/makefile
@@ -1,3 +1,4 @@
+export PATH := ../tools/bin:$(PATH)
 CC = cc
 PREFIX = /usr
 

--- a/makefile
+++ b/makefile
@@ -7,19 +7,19 @@ distro: libc_target coreinutils_target shell/shell.bin misc/life.bin kernel/echi
 
 libc_target:
 	cp gccwrappers/* tools/bin/
-	export PATH=`pwd`/tools/bin:$$PATH && cd libc && $(MAKE)
+	$(MAKE) -C libc
 
 coreinutils_target:
-	export PATH=`pwd`/tools/bin:$$PATH && cd coreinutils && $(MAKE) all
+	$(MAKE) -C coreinutils all
 
 misc/life.bin:
-	export PATH=`pwd`/tools/bin:$$PATH && cd misc && $(MAKE)
+	$(MAKE) -C misc
 
 shell/shell.bin:
-	export PATH=`pwd`/tools/bin:$$PATH && cd shell && $(MAKE)
+	$(MAKE) -C shell
 
 kernel/echidna.bin:
-	export PATH=`pwd`/tools/bin:$$PATH && cd kernel && $(MAKE)
+	$(MAKE) -C kernel
 
 echidnafs/echfs-utils: echidnafs/echfs-utils.c
 	cd echidnafs && gcc echfs-utils.c -o echfs-utils

--- a/makefile
+++ b/makefile
@@ -1,24 +1,24 @@
+LIBC_C_FILES = $(shell find libc -type f -name '*.c')
+COREINUTILS_C_FILES = $(shell find coreinutils/src -type f -name '*.c')
+KERNEL_ASM_FILES = $(shell find kernel -type f -name '*.asm')
+KERNEL_C_FILES = $(shell find kernel -type f -name '*.c')
+
 notarget:
 	$(error No target specified)
 
-distro: libc_target coreinutils_target shell/shell.bin misc/life.bin kernel/echidna.bin
-	$(MAKE) img
-	$(MAKE) clean
-
-libc_target:
-	cp gccwrappers/* tools/bin/
+libc/libc: $(LIBC_C_FILES)
 	$(MAKE) -C libc
 
-coreinutils_target:
+coreinutils/coreinutils: libc/libc $(COREINUTILS_C_FILES)
 	$(MAKE) -C coreinutils all
 
-misc/life.bin:
+misc/life: libc/libc misc/life.c
 	$(MAKE) -C misc
 
-shell/shell.bin:
+shell/sh: libc/libc shell/shell.c
 	$(MAKE) -C shell
 
-kernel/echidna.bin:
+kernel/echidna.bin: $(KERNEL_ASM_FILES) $(KERNEL_C_FILES)
 	$(MAKE) -C kernel
 
 echidnafs/echfs-utils: echidnafs/echfs-utils.c
@@ -31,7 +31,7 @@ clean:
 	cd misc && $(MAKE) clean
 	cd kernel && $(MAKE) clean
 
-img: echidnafs/echfs-utils kernel/echidna.bin
+echidna.img: echidnafs/echfs-utils bootloader/bootloader.asm kernel/echidna.bin shell/sh misc/life
 	nasm bootloader/bootloader.asm -f bin -o echidna.img
 	dd bs=512 count=131032 if=/dev/zero >> ./echidna.img
 	echidnafs/echfs-utils echidna.img format

--- a/misc/makefile
+++ b/misc/makefile
@@ -1,3 +1,4 @@
+export PATH := ../tools/bin:$(PATH)
 CC = cc
 PREFIX = 
 

--- a/shell/makefile
+++ b/shell/makefile
@@ -1,3 +1,4 @@
+export PATH := ../tools/bin:$(PATH)
 CC = cc
 PREFIX = 
 


### PR DESCRIPTION
this replaces `make distro` with `make echidna.img`

this also stops using `make clean`

```
debian:~/src/echidnaOS$ touch kernel/src/syscalls.c

debian:~/src/echidnaOS$ make echidna.img
make -C kernel
make[1]: Entering directory '/home/raylu/src/echidnaOS/kernel'
kcc -std=gnu99 -masm=intel  -c src/syscalls.c -o src/syscalls.o
kcc -o echidna.bin init.o src/dev.o src/drivers/keyboard.o src/drivers/panic.o src/drivers/exceptions.o src/drivers/streams/streams.o src/drivers/gdt.o src/drivers/pcspk/pcspk.o src/drivers/pic.o src/drivers/stty/stty.o src/drivers/com/com.o src/drivers/tty.o src/drivers/pit.o src/drivers/ata/ata.o src/drivers/vdev/vdev.o src/drivers/tty/tty.o src/syscalls.o src/task.o src/fs/devfs.o src/fs/echfs.o src/vfs.o src/klib.o asm/mem.o asm/idt.o asm/tss.o asm/isr.o asm/real.o asm/video.o asm/task.o
make[1]: Leaving directory '/home/raylu/src/echidnaOS/kernel'
make -C shell
make[1]: Entering directory '/home/raylu/src/echidnaOS/shell'
make[1]: 'sh' is up to date.
make[1]: Leaving directory '/home/raylu/src/echidnaOS/shell'
make -C misc
make[1]: Entering directory '/home/raylu/src/echidnaOS/misc'
make[1]: 'life' is up to date.
make[1]: Leaving directory '/home/raylu/src/echidnaOS/misc'
nasm bootloader/bootloader.asm -f bin -o echidna.img
dd bs=512 count=131032 if=/dev/zero >> ./echidna.img
131032+0 records in
131032+0 records out
67088384 bytes (67 MB, 64 MiB) copied, 0.146415 s, 458 MB/s
echidnafs/echfs-utils echidna.img format
echidnafs/echfs-utils echidna.img mkdir dev
echidnafs/echfs-utils echidna.img mkdir bin
echidnafs/echfs-utils echidna.img mkdir docs
echidnafs/echfs-utils echidna.img import ./kernel/echidna.bin echidna.bin
echidnafs/echfs-utils echidna.img import ./shell/sh /bin/sh
echidnafs/echfs-utils echidna.img import ./misc/life /bin/life
echidnafs/echfs-utils echidna.img import ./coreinutils/build/yes /bin/yes
echidnafs/echfs-utils echidna.img import ./coreinutils/build/hello /bin/hello
echidnafs/echfs-utils echidna.img import ./coreinutils/build/true /bin/true
echidnafs/echfs-utils echidna.img import ./coreinutils/build/cp /bin/cp
echidnafs/echfs-utils echidna.img import ./coreinutils/build/rm /bin/rm
echidnafs/echfs-utils echidna.img import ./coreinutils/build/mv /bin/mv
echidnafs/echfs-utils echidna.img import ./coreinutils/build/echo /bin/echo
echidnafs/echfs-utils echidna.img import ./coreinutils/build/false /bin/false
echidnafs/echfs-utils echidna.img import ./coreinutils/build/cat /bin/cat
echidnafs/echfs-utils echidna.img import ./coreinutils/build/touch /bin/touch
echidnafs/echfs-utils echidna.img import ./coreinutils/build/printf /bin/printf
echidnafs/echfs-utils echidna.img import ./LICENSE.md /docs/license

debian:~/src/echidnaOS$ make echidna.img
make -C shell
make[1]: Entering directory '/home/raylu/src/echidnaOS/shell'
make[1]: 'sh' is up to date.
make[1]: Leaving directory '/home/raylu/src/echidnaOS/shell'
make -C misc
make[1]: Entering directory '/home/raylu/src/echidnaOS/misc'
make[1]: 'life' is up to date.
make[1]: Leaving directory '/home/raylu/src/echidnaOS/misc'
```